### PR TITLE
Change javet version to 1.1.0 in sass-dart-asset-pipeline

### DIFF
--- a/sass-dart-asset-pipeline/build.gradle
+++ b/sass-dart-asset-pipeline/build.gradle
@@ -19,7 +19,7 @@ sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
 
 ext {
-    javetVersion = "1.0.6"
+    javetVersion = "1.1.0"
     isReleaseVersion = !version.endsWith("SNAPSHOT")
 }
 


### PR DESCRIPTION
Use of the sass-dart-asset-pipeline with older linux distributions.

We are using Mac OS M1 for development but CentOS 7 in our CI/CD systems so the existing javet version 1.0.6 doesn't cover us. We need to use version 1.1.0 that supports older linux os